### PR TITLE
Functorise the Allocator over the 'physical volume'

### DIFF
--- a/lib/allocator.mli
+++ b/lib/allocator.mli
@@ -12,41 +12,6 @@
  * GNU Lesser General Public License for more details.
  *)
 
-type area = string * (int64 * int64)
-(** a contiguous fragment of physical space on a named volume *)
-
-type t = area list
-(** contiguous virtual space represented by an ordered list of 'areas' *)
-
-include S.SEXPABLE with type t := t
-include S.PRINT with type t := t
-
-val create: string -> int64 -> t
-(** [create name length] creates a single allocation from the entity
-    with [name] covering region [0...length] *)
-
-val get_name: area -> string
-val get_start: area -> int64
-val get_size: area -> int64
-val get_end: area -> int64
-
-(** [find free_space size] attempts to find space within [t] of total size
-    [size]. If successful it returns a [t]. If it fails it returns the
-    total amount of space currently free, which is insufficient to satisfy
-    the request.
-    The expected use is to 'allocate' space for a logical volume. *)
-val find : t -> int64 -> (t, int64) Result.result
-
-(** [merge t1 t2] returns a region [t] which contains all the physical
-    space from both [t1] and [t2].
-    The expected use is to return a previously-allocated [t] to a [t] which
-    represents the free space. *)
-val merge : t -> t -> t
-
-(** [sub t1 t2] returns [t1] with all the space from [t2] removed.
-    The expected use is to compute the remaining free space once space for
-    a volume has been removed. *)
-val sub : t -> t -> t
-
-(** [size t] returns the total size of [t] *)
-val size : t -> int64
+module Make(Name: S.NAME):
+  S.ALLOCATOR
+    with type name = Name.t

--- a/lib/pv.ml
+++ b/lib/pv.ml
@@ -124,3 +124,9 @@ let format real_device name =
   return { name; id; stored_device = real_device; real_device; status=[Status.Allocatable];
            size_in_sectors; pe_start; pe_count; label; headers = [mda_header]; }
 end
+
+module Allocator = Allocator.Make(struct
+  type t = string with sexp
+  let compare (a: t) (b: t) = compare a b
+  let to_string x = x
+end)

--- a/lib/pv.mli
+++ b/lib/pv.mli
@@ -54,3 +54,6 @@ module Make : functor(DISK: S.DISK) -> sig
   (** [read name config] reads the information of physical volume [name]
       with configuration [config] read from the volume group metadata. *)
 end
+
+module Allocator: S.ALLOCATOR
+  with type name = string

--- a/lib/redo.ml
+++ b/lib/redo.ml
@@ -17,7 +17,7 @@ open Logging
 
 type lvcreate_t = {
   lvc_id : Uuid.t;
-  lvc_segments : Allocator.t
+  lvc_segments : Pv.Allocator.t
 }
 
 and lvrename_t = {
@@ -29,7 +29,7 @@ and lvreduce_t = {
 }
 
 and lvexpand_t = {
-  lvex_segments : Allocator.t;
+  lvex_segments : Pv.Allocator.t;
 }
 
 (** First string corresponds to the name of the LV. *)
@@ -120,9 +120,9 @@ let reset fd offset =
 (** Converts the redo operation to a human-readable string. *)
 let redo_to_human_readable op =
 	let lvcreate_t_to_string l =
-		Printf.sprintf "{id:'%s', segments:[%s]}" (Uuid.to_string l.lvc_id) (Allocator.to_string l.lvc_segments) in
+		Printf.sprintf "{id:'%s', segments:[%s]}" (Uuid.to_string l.lvc_id) (Pv.Allocator.to_string l.lvc_segments) in
 	let lvexpand_t_to_string l =
-		Printf.sprintf "[%s]" (Allocator.to_string l.lvex_segments) in
+		Printf.sprintf "[%s]" (Pv.Allocator.to_string l.lvex_segments) in
 	let opstr =
 		match op.so_op with
 			| LvCreate (name,lvc) -> Printf.sprintf "LvCreate(%s,%s)" name (lvcreate_t_to_string lvc)

--- a/lib/s.mli
+++ b/lib/s.mli
@@ -96,3 +96,50 @@ module type VOLUME = sig
       volume with [name] has no tag [tag] *)
 end
 
+module type NAME = sig
+  include Map.OrderedType
+  include SEXPABLE with type t := t
+  include PRINT with type t := t
+end
+
+module type ALLOCATOR = sig
+
+  type name with sexp
+
+  type area = name * (int64 * int64)
+  (** a contiguous fragment of physical space on a volume ['a] *)
+
+  type t = area list with sexp
+
+  val to_string: t -> string
+
+  val create: name -> int64 -> t
+  (** [create name length] creates a single allocation from the entity
+      with [name] covering region [0...length] *)
+
+  val get_name: area -> name
+  val get_start: area -> int64
+  val get_size: area -> int64
+  val get_end: area -> int64
+
+  (** [find free_space size] attempts to find space within [t] of total size
+      [size]. If successful it returns a [t]. If it fails it returns the
+      total amount of space currently free, which is insufficient to satisfy
+      the request.
+      The expected use is to 'allocate' space for a logical volume. *)
+  val find : t -> int64 -> (t, int64) Result.result
+
+  (** [merge t1 t2] returns a region [t] which contains all the physical
+      space from both [t1] and [t2].
+      The expected use is to return a previously-allocated [t] to a [t] which
+      represents the free space. *)
+  val merge : t -> t -> t
+
+  (** [sub t1 t2] returns [t1] with all the space from [t2] removed.
+      The expected use is to compute the remaining free space once space for
+      a volume has been removed. *)
+  val sub : t -> t -> t
+
+  (** [size t] returns the total size of [t] *)
+  val size : t -> int64
+end

--- a/lib/vg.mli
+++ b/lib/vg.mli
@@ -34,7 +34,7 @@ type t = {
   max_pv : int;
   pvs : Pv.t list;              (** physical volumes *)
   lvs : Lv.t list;              (** logical volumes *)
-  free_space : Allocator.t;     (** free space in physical volumes, which can be used for logical volumes *)
+  free_space : Pv.Allocator.t;  (** free space in physical volumes, which can be used for logical volumes *)
   ops : Redo.sequenced_op list; (** a list of uncommitted operations *)
 }
 (** A volume group *)

--- a/lib_test/allocator_test.ml
+++ b/lib_test/allocator_test.ml
@@ -13,7 +13,7 @@
  *)
 
 open Kaputt.Abbreviations
-open Lvm.Allocator
+open Lvm.Pv.Allocator
 
 let id a = a
 let ($) f a = f a

--- a/src/impl.ml
+++ b/src/impl.ml
@@ -77,7 +77,7 @@ let table_of_vg vg =
   [ "max_lv"; string_of_int vg.Vg.max_lv ];
   [ "max_pv"; string_of_int vg.Vg.max_pv ];
 ] @ pvs @ lvs @ [
-  [ "free_space"; Int64.to_string (Allocator.size vg.Vg.free_space) ];
+  [ "free_space"; Int64.to_string (Pv.Allocator.size vg.Vg.free_space) ];
 ]
 
 let read common filename =


### PR DESCRIPTION
In the case of the PV allocator we identify physical volumes by
their string names. The core allocator logic doesn't require the
name to be a string, any ordered type will do. This will allow
the allocator to be used over other types, including devicemapper
target locations.

Signed-off-by: David Scott dave.scott@citrix.com
