### PR TITLE
Fix expand, make API idempotent

### DIFF
--- a/lib/lv.ml
+++ b/lib/lv.ml
@@ -110,6 +110,17 @@ module Segment = struct
 		    (name,(start,allocated_extents)))
 	  (st.Stripe.stripes)
 
+  let linear s_start_extent ss =
+    let rec loop acc ss s_start_extent = match ss with
+    | a::ss ->
+      let start_extent = Pv.Allocator.get_start a in
+      let extent_count = Pv.Allocator.get_size a in
+      let name = Pv.Allocator.get_name a in
+      let cls = Linear { Linear.name; start_extent; } in
+      loop ({ start_extent; cls; extent_count } :: acc) ss  (Int64.add start_extent extent_count)
+    | [] -> List.rev acc in
+    loop [] ss s_start_extent
+
 end
 
 type t = {

--- a/lib/lv.ml
+++ b/lib/lv.ml
@@ -117,7 +117,7 @@ module Segment = struct
       let extent_count = Pv.Allocator.get_size a in
       let name = Pv.Allocator.get_name a in
       let cls = Linear { Linear.name; start_extent; } in
-      loop ({ start_extent; cls; extent_count } :: acc) ss  (Int64.add start_extent extent_count)
+      loop ({ start_extent = s_start_extent; cls; extent_count } :: acc) ss  (Int64.add s_start_extent extent_count)
     | [] -> List.rev acc in
     loop [] ss s_start_extent
 

--- a/lib/lv.mli
+++ b/lib/lv.mli
@@ -55,6 +55,10 @@ module Segment : sig
 
   val to_allocation: t -> (string * (int64 * int64)) list
   (** Compute the physical extents occupied by the storage *)
+
+  val linear: int64 -> Pv.Allocator.t -> t list
+  (** [create segment space] creates segments mapping from
+      [segment] linearly covering all the [space] *)
 end
 
 type t = {

--- a/lib/lv.mli
+++ b/lib/lv.mli
@@ -66,6 +66,8 @@ type t = {
   id : Uuid.t;               (** arbitrary unique id *)
   tags : Tag.t list;         (** tags given by the user *)
   status : Status.t list;    (** status flags *)
+  (* TODO: this must be written in ascending order of start_extent.
+     Should we convert this into a Map? *)
   segments : Segment.t list; (** an ordered list of blocks ('segments') *)
 } with sexp
 (** a logical volume within a volume group *)

--- a/lib/lv.mli
+++ b/lib/lv.mli
@@ -54,6 +54,7 @@ module Segment : sig
   val sort: t list -> t list
 
   val to_allocation: t -> (string * (int64 * int64)) list
+  (** Compute the physical extents occupied by the storage *)
 end
 
 type t = {

--- a/lib/redo.ml
+++ b/lib/redo.ml
@@ -30,7 +30,7 @@ module Op = struct
   }
 
   and lvexpand_t = {
-    lvex_segments : Pv.Allocator.t;
+    lvex_segments : Lv.Segment.t list;
   } with sexp
 
   (** First string corresponds to the name of the LV. *)

--- a/lib/vg.ml
+++ b/lib/vg.ml
@@ -116,7 +116,8 @@ let do_op vg op : (t * op, string) Result.result =
              then last_start, acc
              else segment.Lv.Segment.start_extent, segment :: acc
            ) (-1L, [])
-        |> snd in
+        |> snd
+        |> List.rev in
       let lv = {lv with Lv.segments} in
       return ({vg with lvs = lv::others; free_space=free_space},op))
   | LvReduce (name,l) ->

--- a/lib/vg.mli
+++ b/lib/vg.mli
@@ -38,6 +38,9 @@ type t = {
 }
 (** A volume group *)
 
+val do_op: t -> Redo.Op.t -> (t * Redo.Op.t, string) Result.result
+(** [do_op t op] performs [op], returning the modified volume group [t] *)
+
 include S.SEXPABLE with type t := t
 include S.MARSHAL with type t := t
 include S.VOLUME


### PR DESCRIPTION
- Redo clients need to provide the new segments, not simply free space
- `createsegs` is now an exposed function
- `createsegs` was using the wrong start_extent
- add note that Segments must be written sorted into ascending order of start_extent
