### PR TITLE
Add a 'Crop' operation

### DIFF
--- a/lib/allocator.ml
+++ b/lib/allocator.ml
@@ -135,25 +135,12 @@ let normalize areas =
 
     M.fold (fun name pairs acc -> List.map (fun p -> name, p) pairs @ acc) by_name []
 
-(* Which invariants does t have to satisfy?  Which invariants does our
-   result here satisfy?
-
-   E.g. is it possible for areas to overlap or contain each other?  If not, should we warn if they do?
-
-   t is a free list.
-
-   What if there's no containing area? Is this only called under certain circumstances? Verify. *)
-exception NonSingular_Containing_Area
 let alloc_specified_area (free_list : t) (a : area) =
     if get_size a = 0L
     then free_list
     else
-    (* We assume areas don't overlap, or do we? *)
-    (* Match against [] instead of _: Better die as soon as possible, when something is wrong. 
-     * And that was right!  Just caught a bug that would have been masked otherwise. *)
-    match List.partition (contained a) ++ normalize $ free_list with
-	| (containing_area::[]), other_areas -> normalize $ combine (minus containing_area a) other_areas
-	| x,_ -> raise NonSingular_Containing_Area
+        let t = List.concat (List.map (fun x -> minus x a) free_list) in
+        normalize t
 
 let sub : t -> t -> t =
    List.fold_left alloc_specified_area

--- a/lib/redo.ml
+++ b/lib/redo.ml
@@ -29,6 +29,10 @@ module Op = struct
     lvrd_new_extent_count : int64;
   }
 
+  and lvcrop_t = {
+    lvc_segments: Lv.Segment.t list;
+  }
+
   and lvexpand_t = {
     lvex_segments : Lv.Segment.t list;
   } with sexp
@@ -37,6 +41,7 @@ module Op = struct
   type t =
     | LvCreate of string * lvcreate_t
     | LvReduce of string * lvreduce_t
+    | LvCrop   of string * lvcrop_t
     | LvExpand of string * lvexpand_t
     | LvRename of string * lvrename_t
     | LvRemove of string

--- a/lib/vg.ml
+++ b/lib/vg.ml
@@ -120,6 +120,15 @@ let do_op vg op : (t * op, string) Result.result =
         |> List.rev in
       let lv = {lv with Lv.segments} in
       return ({vg with lvs = lv::others; free_space=free_space},op))
+  | LvCrop (name, l) ->
+    change_lv name (fun lv others ->
+      let current = Lv.to_allocation lv in
+      let to_free = List.fold_left Pv.Allocator.merge [] (List.map Lv.Segment.to_allocation l.lvc_segments) in
+      let reduced = Pv.Allocator.sub current to_free in
+      let free_space = Pv.Allocator.merge vg.free_space to_free in
+
+      let segments = Lv.Segment.linear 0L reduced in
+      return ({vg with lvs = lv::others; free_space},op))
   | LvReduce (name,l) ->
     change_lv name (fun lv others ->
       let allocation = Lv.to_allocation lv in


### PR DESCRIPTION
This is a bit of a Work-in-Progress, but I'm working under the assumption that all idempotent operations ought to be in the Redo module.

This operation is a bit specific to my particular lvhd use-case: it removes blocks from the middle of an LV and renumbers the remainder to make the LV contiguous again.
