### PR TITLE
Stop using the device hint in the metadata to find devices

### DIFF
--- a/lib/pv.mli
+++ b/lib/pv.mli
@@ -50,8 +50,8 @@ module Make : functor(Block: S.BLOCK) -> sig
   (** [read_metadata device]: locates the metadata area on [device] and
       returns the volume group metadata. *)
 
-  val read: string -> (string * Absty.absty) list -> t S.io
-  (** [read name config] reads the information of physical volume [name]
+  val read: string -> string -> (string * Absty.absty) list -> t S.io
+  (** [read device name config] reads the information of physical volume [name]
       with configuration [config] read from the volume group metadata. *)
 end
 


### PR DESCRIPTION
Instead we read the PV headers from each device, extract the (uu)id
and match this with the VG metadata.

To prove that we aren't using the device hint, explicitly set it to
"/dev/null".

Signed-off-by: David Scott dave.scott@citrix.com
