### PR TITLE
Don't call BLOCK.connect

### DIFF
--- a/lib/label.mli
+++ b/lib/label.mli
@@ -51,12 +51,11 @@ module Pv_header : sig
 end
 
 type t = {
-  device : string;
   label_header : Label_header.t;
   pv_header : Pv_header.t;
 }
 
-val create: string -> ?magic:Magic.t -> Uuid.t -> int64 -> int64 -> int64 -> t
+val create: ?magic:Magic.t -> Uuid.t -> int64 -> int64 -> int64 -> t
 
 include S.EQUALS with type t := t
 include S.PRINT with type t := t
@@ -69,10 +68,8 @@ val get_metadata_locations: t -> Location.t list
 
 val get_pv_id: t -> Uuid.t
 
-val get_device: t -> string
-
 module Make : functor(Block: S.BLOCK) -> sig
-  val read: string -> t S.io
+  val read: Block.t -> t S.io
 
-  val write: t -> unit S.io
+  val write: Block.t -> t -> unit S.io
 end

--- a/lib/metadata.mli
+++ b/lib/metadata.mli
@@ -30,13 +30,13 @@ module Header: sig
 
   module Make : functor(Block: S.BLOCK) -> sig
 
-    val write: t -> string -> unit S.io
+    val write: t -> Block.t -> unit S.io
     (** [write t device] writes [t] to the [device] *)
 
-    val read: string -> Label.Location.t -> t S.io
+    val read: Block.t -> Label.Location.t -> t S.io
     (** [read device location] reads [t] from the [device] *)
 
-    val read_all: string -> Label.Location.t list -> t list S.io
+    val read_all: Block.t -> Label.Location.t list -> t list S.io
     (** [read device locations] reads the [t]s found at [location]s,
         or an error if any single one can't be read. *)
   end
@@ -52,7 +52,7 @@ val default_size: int64
 (** Default length of the metadata area in bytes *)
 
 module Make : functor(Block: S.BLOCK) -> sig
-  val read: string -> Header.t -> int -> Cstruct.t S.io
+  val read: Block.t -> Header.t -> int -> Cstruct.t S.io
 
-  val write: string -> Header.t -> Cstruct.t -> Header.t S.io
+  val write: Block.t -> Header.t -> Cstruct.t -> Header.t S.io
 end

--- a/lib/pv.ml
+++ b/lib/pv.ml
@@ -113,9 +113,9 @@ let format device ?(magic=`Lvm) name =
   let pe_count = Int64.(div (sub size pe_start_byte) Constants.extent_size) in
   let mda_len = Int64.sub pe_start_byte mda_pos in
   let id=Uuid.create () in
-  let label = Label.create device ~magic id size mda_pos mda_len in
+  let label = Label.create ~magic id size mda_pos mda_len in
   let mda_header = Metadata.Header.create magic in
-  Label_IO.write label >>= fun () ->
+  Label_IO.write device label >>= fun () ->
   Header_IO.write mda_header device >>= fun () ->
   return { name; id; status=[Status.Allocatable];
            size_in_sectors; pe_start; pe_count; label; headers = [mda_header]; }

--- a/lib/pv.mli
+++ b/lib/pv.mli
@@ -38,17 +38,17 @@ include S.PRINT with type t := t
 include S.MARSHAL with type t := t
 
 module Make : functor(Block: S.BLOCK) -> sig
-  val format: string -> ?magic: Magic.t -> string -> t S.io
+  val format: Block.t -> ?magic: Magic.t -> string -> t S.io
   (** [format device ?kind name] initialises a physical volume on [device]
       with [name]. One metadata area will be created, 10 MiB in size,
       at a fixed location. Any existing metadata on this device will
       be destroyed. *)
 
-  val read_metadata: string -> Cstruct.t S.io
+  val read_metadata: Block.t -> Cstruct.t S.io
   (** [read_metadata device]: locates the metadata area on [device] and
       returns the volume group metadata. *)
 
-  val read: string -> string -> (string * Absty.absty) list -> t S.io
+  val read: Block.t -> string -> (string * Absty.absty) list -> t S.io
   (** [read device name config] reads the information of physical volume [name]
       with configuration [config] read from the volume group metadata. *)
 end

--- a/lib/s.mli
+++ b/lib/s.mli
@@ -40,11 +40,7 @@ end
 
 type 'a io = ('a, string) Result.result Lwt.t
 
-module type BLOCK = sig
-  include V1_LWT.BLOCK
-
-  val connect: string -> [ `Ok of t | `Error of error ] Lwt.t
-end
+module type BLOCK = V1_LWT.BLOCK
 
 module type VOLUME = sig
 

--- a/lib/vg.mli
+++ b/lib/vg.mli
@@ -52,16 +52,16 @@ include S.VOLUME
 
 module Make : functor(Block: S.BLOCK) -> sig
 
-  val format: string -> ?magic:Magic.t -> (string * string) list -> unit S.io
-  (** [format name names_and_devices] initialises a new volume group
+  val format: string -> ?magic:Magic.t -> (Block.t * string) list -> unit S.io
+  (** [format name devices_and_names] initialises a new volume group
       with name [name], using physical volumes
-      [names_and_devices = [ name1, device1; ...]] *)
+      [device_and_names = [ device1, name1; ...]] *)
 
-  val read: string list -> t S.io
+  val read: Block.t list -> t S.io
   (** [read devices] reads the volume group information from
       the set of physical volumes [devices] *)
 
-  val write: string list -> t -> t S.io
+  val write: Block.t list -> t -> t S.io
   (** [write devices t] flushes the metadata of [t] to the physical volumes *)
 
 end

--- a/lib_test/tag_test.ml
+++ b/lib_test/tag_test.ml
@@ -78,7 +78,7 @@ let well_known_label () =
   let sector = Cstruct.create 512 in
   Utils.zero sector;
   let uuid = Result.ok_or_failwith (Uuid.of_string "Obwn1M-Gs3G-3TN8-Rchu-o73n-KTT0-uLuUxw") in
-  let expected = create "foo" uuid 1234L 100L 200L in
+  let expected = create uuid 1234L 100L 200L in
   let _ = marshal expected sector in
   let label' = Cstruct.(to_string (sub sector 0 (String.length label))) in
   assert_equal label label'


### PR DESCRIPTION
The Mirage policy is to pass in `BLOCK.t` values and libraries shouldn't call `BLOCK.connect` themselves.
