### PR TITLE
The Vg interface is safer and exposes LVs as BLOCK devices

### DIFF
--- a/lib/lv.ml
+++ b/lib/lv.ml
@@ -197,7 +197,17 @@ let to_allocation lv =
 let size_in_extents lv =
   List.fold_left (Int64.add) 0L
     (List.map (fun seg -> seg.Segment.extent_count) lv.segments)
-	    
+
+let find_extent lv e =
+  (* XXX: we need a more efficient structure than a list *)
+  List.fold_left (fun acc x -> match acc, x with
+    | Some x, _ -> Some x
+    | None, { Segment.start_extent = s; extent_count = l } ->
+      if s <= e && e <= (Int64.add s l)
+      then Some x
+      else None
+    ) None lv.segments
+ 
 let reduce_size_to lv new_seg_count =
   let cur_size = size_in_extents lv in
   debug "Beginning reduce_size_to:";

--- a/lib/lv.mli
+++ b/lib/lv.mli
@@ -81,6 +81,9 @@ val to_allocation: t -> (Pv.Name.t * (int64 * int64)) list
 
 val size_in_extents: t -> int64
 
+val find_extent: t -> int64 -> Segment.t option
+(** [find_extent t x] returns the segment containing [x] *)
+
 val reduce_size_to: t -> int64 -> (t, string) Result.result
 (** [reduce_size_to lv new_size] reduces the size of [lv] to [new_size],
     or fails if the [new_size] is less than the current size. *)

--- a/lib/vg.ml
+++ b/lib/vg.ml
@@ -215,11 +215,6 @@ type t = metadata * devices
 
 let metadata_of = fst
 let devices_of = snd
-let update (metadata, devices) op =
-  let open Result in
-  do_op metadata op
-  >>= fun (metadata', _) ->
-  return (metadata', devices)
 
 let id_to_devices devices =
   (* We need the uuid contained within the Pv_header to figure out
@@ -265,6 +260,12 @@ let write (vg, name_to_devices) =
   write_vg [] vg.pvs >>= fun pvs ->
   let vg = { vg with pvs } in
   return (vg, name_to_devices)
+
+let update (metadata, devices) op =
+  let open IO.FromResult in
+  do_op metadata op
+  >>= fun (metadata', _) ->
+  write (metadata', devices)
 
 let format name ?(magic = `Lvm) devices =
   let open IO in

--- a/lib/vg.ml
+++ b/lib/vg.ml
@@ -261,11 +261,18 @@ let write (vg, name_to_devices) =
   let vg = { vg with pvs } in
   return (vg, name_to_devices)
 
-let update (metadata, devices) op =
+let update (metadata, devices) ops =
+  let open Result in
+  let rec loop metadata = function
+    | [] -> return metadata
+    | x :: xs ->
+      do_op metadata x
+      >>= fun (metadata, _) ->
+      loop metadata xs in
   let open IO.FromResult in
-  do_op metadata op
-  >>= fun (metadata', _) ->
-  write (metadata', devices)
+  loop metadata ops
+  >>= fun metadata ->
+  write (metadata, devices)
 
 let format name ?(magic = `Lvm) devices =
   let open IO in

--- a/lib/vg.ml
+++ b/lib/vg.ml
@@ -211,7 +211,7 @@ open IO
 
 type devices = (Pv.Name.t * Block.t) list
 
-type t = metadata * devices
+type vg = metadata * devices
 
 let metadata_of = fst
 let devices_of = snd
@@ -363,6 +363,111 @@ let read devices =
      )
   |> List.fold_left (fun acc x -> match x with None -> acc | Some x -> x :: acc) [] in
   return (vg, name_to_devices)
+
+module Volume = struct
+  type id = {
+    vg_name: string;
+    lv_name: string;
+  }
+  type t = {
+    id: id;
+    devices: devices;
+    sector_size: int;
+    extent_size: int64;
+    lv: Lv.t;
+    mutable disconnected: bool;
+  }
+
+  let id t = t.id
+
+  type error = [
+    | `Unknown of string
+    | `Unimplemented
+    | `Is_read_only
+    | `Disconnected
+  ]
+
+  type info = {
+    read_write: bool;
+    sector_size: int;
+    size_sectors: int64;
+  }
+
+  type 'a io = 'a Lwt.t
+
+  type page_aligned_buffer = Cstruct.t
+
+  open Lwt
+
+  let connect (metadata, devices) name =
+    match try Some (List.find (fun x -> x.Lv.name = name) metadata.lvs) with Not_found -> None with
+    | None -> return (`Error (`Unknown (Printf.sprintf "There is no volume named '%s'" name)))
+    | Some lv ->
+      (* We require all the devices to have identical sector sizes *)
+      Lwt_list.map_p
+        (fun (_, device) ->
+          Block.get_info device
+          >>= fun info ->
+          return info.Block.sector_size
+        ) devices
+      >>= fun sizes ->
+      let biggest = List.fold_left max min_int sizes in
+      let smallest = List.fold_left min max_int sizes in
+      if biggest <> smallest
+      then return (`Error (`Unknown (Printf.sprintf "The underlying block devices have mixed sector sizes: %d <> %d" smallest biggest)))
+      else
+        let id = { vg_name = metadata.name; lv_name = name } in
+        return (`Ok {
+          id; devices; sector_size = biggest; extent_size = metadata.extent_size;
+          disconnected = false; lv
+        })
+
+  let get_info t =
+    let read_write = List.mem Lv.Status.Write t.lv.Lv.status in
+    let segments = List.fold_left (fun acc s -> Int64.add acc s.Lv.Segment.extent_count) 0L t.lv.Lv.segments in
+    let size_sectors = Int64.mul segments t.extent_size in
+    return { read_write; sector_size = t.sector_size; size_sectors }
+
+  let (>>|=) m f = m >>= function
+  | `Error e -> return (`Error e)
+  | `Ok x -> f x
+  
+  let io op t sector_start buffers =
+    if t.disconnected
+    then return (`Error `Disconnected)
+    else begin
+      let rec loop sector_start = function
+      | [] -> return (`Ok ())
+      | b :: bs ->
+        let start_le = Int64.div sector_start t.extent_size in
+        let start_offset = Int64.rem sector_start t.extent_size in
+        match Lv.find_extent t.lv start_le with
+        | Some { Lv.Segment.cls = Lv.Segment.Linear l; start_extent; extent_count } ->
+          let start_pe = Int64.(add l.Lv.Linear.start_extent (sub start_le start_extent)) in
+          let phys_offset = Int64.(add (mul start_pe t.extent_size) start_offset) in
+          let will_read = min (Cstruct.len b / t.sector_size) (Int64.to_int t.extent_size) in
+          if List.mem_assoc l.Lv.Linear.name t.devices then begin
+            let device = List.assoc l.Lv.Linear.name t.devices in
+            op device phys_offset [ Cstruct.sub b 0 (will_read * t.sector_size) ]
+            >>|= fun () ->
+            let b = Cstruct.shift b (will_read * t.sector_size) in
+            let bs = if Cstruct.len b > 0 then b :: bs else bs in
+            let sector_start = Int64.(add sector_start (of_int will_read)) in
+            loop sector_start bs
+          end else return (`Error (`Unknown (Printf.sprintf "Unknown physical volume %s" (Pv.Name.to_string l.Lv.Linear.name))))
+        | Some _ -> return (`Error (`Unknown "I only understand linear mapping"))
+        | None -> return (`Error (`Unknown (Printf.sprintf "Logical extent %Ld has no segment" start_le))) in
+      loop sector_start buffers
+    end
+
+  let read = io Block.read
+  let write = io Block.write
+
+  let disconnect t =
+    t.disconnected <- true;
+    return ()
+end
+
 end
 (*
 let set_dummy_mode base_dir mapper_name full_provision =

--- a/lib/vg.ml
+++ b/lib/vg.ml
@@ -219,10 +219,10 @@ let id_to_devices devices =
     return (label.Label.pv_header.Label.Pv_header.id, device)
   ) devices)
 
-let write devices vg =
+let write (vg, name_to_devices) =
+  let devices = List.map snd name_to_devices in
   id_to_devices devices
-  >>= function
-  | id_to_devices ->
+  >>= fun id_to_devices ->
 
   let buf = Cstruct.create (Int64.to_int Constants.max_metadata_size) in
   let buf' = marshal vg buf in
@@ -269,7 +269,7 @@ let format name ?(magic = `Lvm) devices =
   let vg = { name; id=Uuid.create (); seqno=1; status=[Status.Read; Status.Write];
     extent_size=Constants.extent_size_in_sectors; max_lv=0; max_pv=0; pvs;
     lvs=[]; free_space; } in
-  write (List.map snd devices) vg >>= fun _ ->
+  write (vg, devices) >>= fun _ ->
   debug "VG created";
   return ()
 

--- a/lib/vg.ml
+++ b/lib/vg.ml
@@ -215,7 +215,11 @@ type t = metadata * devices
 
 let metadata_of = fst
 let devices_of = snd
-let update (_, devices) metadata = metadata, devices
+let update (metadata, devices) op =
+  let open Result in
+  do_op metadata op
+  >>= fun (metadata', _) ->
+  return (metadata', devices)
 
 let id_to_devices devices =
   (* We need the uuid contained within the Pv_header to figure out

--- a/lib/vg.mli
+++ b/lib/vg.mli
@@ -65,8 +65,9 @@ module Make : functor(Block: S.BLOCK) -> sig
   (** [read devices] reads the volume group information from
       the set of physical volumes [devices] *)
 
-  val update: vg -> Redo.Op.t -> vg S.io
-  (** [update t update] replaces the metadata within [t] with [update] *)
+  val update: vg -> Redo.Op.t list -> vg S.io
+  (** [update t updates] performs the operations [updates] and
+      writes the new metadata back. *)
 
   module Volume : sig
     include V1_LWT.BLOCK

--- a/lib/vg.mli
+++ b/lib/vg.mli
@@ -52,14 +52,14 @@ include S.VOLUME
 
 module Make : functor(Block: S.BLOCK) -> sig
 
-  type devices = (Pv.Name.t * Block.t) list
+  type devices
   (** The set of local physical devices containing the PVs *)
 
-  val format: string -> ?magic:Magic.t -> devices -> unit S.io
+  val format: string -> ?magic:Magic.t -> (Pv.Name.t * Block.t) list -> unit S.io
   (** [format name devices_and_names] initialises a new volume group
       with name [name], using physical volumes [devices] *)
 
-  val read: Block.t list -> t S.io
+  val read: Block.t list -> (t * devices) S.io
   (** [read devices] reads the volume group information from
       the set of physical volumes [devices] *)
 

--- a/lib/vg.mli
+++ b/lib/vg.mli
@@ -52,10 +52,12 @@ include S.VOLUME
 
 module Make : functor(Block: S.BLOCK) -> sig
 
-  val format: string -> ?magic:Magic.t -> (Block.t * Pv.Name.t) list -> unit S.io
+  type devices = (Pv.Name.t * Block.t) list
+  (** The set of local physical devices containing the PVs *)
+
+  val format: string -> ?magic:Magic.t -> devices -> unit S.io
   (** [format name devices_and_names] initialises a new volume group
-      with name [name], using physical volumes
-      [device_and_names = [ device1, name1; ...]] *)
+      with name [name], using physical volumes [devices] *)
 
   val read: Block.t list -> t S.io
   (** [read devices] reads the volume group information from

--- a/lib/vg.mli
+++ b/lib/vg.mli
@@ -71,8 +71,8 @@ module Make : functor(Block: S.BLOCK) -> sig
   (** [read devices] reads the volume group information from
       the set of physical volumes [devices] *)
 
-  val update: t -> metadata -> t
-  (** [update t metadata] replaces the metadata within [t] with [metadata] *)
+  val update: t -> Redo.Op.t -> (t, string) Result.result
+  (** [update t update] replaces the metadata within [t] with [update] *)
 
   val write: t -> t S.io
   (** [write devices t] flushes the metadata of [t] to the physical volumes *)

--- a/lib/vg.mli
+++ b/lib/vg.mli
@@ -51,26 +51,27 @@ include S.VOLUME
 
 module Make : functor(Block: S.BLOCK) -> sig
 
-  type t
+  type vg
   (** A volume group spread over a set of block devices *)
 
-  type devices
-  (** The set of local physical devices containing the PVs *)
-
-  val metadata_of: t -> metadata
+  val metadata_of: vg -> metadata
   (** Extract a snapshot of the volume group metadata *)
-
-  val devices_of: t -> devices
-  (** Extract the block devices containing the PVs *)
 
   val format: string -> ?magic:Magic.t -> (Pv.Name.t * Block.t) list -> unit S.io
   (** [format name devices_and_names] initialises a new volume group
       with name [name], using physical volumes [devices] *)
 
-  val read: Block.t list -> t S.io
+  val read: Block.t list -> vg S.io
   (** [read devices] reads the volume group information from
       the set of physical volumes [devices] *)
 
-  val update: t -> Redo.Op.t -> t S.io
+  val update: vg -> Redo.Op.t -> vg S.io
   (** [update t update] replaces the metadata within [t] with [update] *)
+
+  module Volume : sig
+    include V1_LWT.BLOCK
+
+    val connect: vg -> string -> [ `Ok of t | `Error of error ] Lwt.t
+
+  end
 end

--- a/lib/vg.mli
+++ b/lib/vg.mli
@@ -63,7 +63,7 @@ module Make : functor(Block: S.BLOCK) -> sig
   (** [read devices] reads the volume group information from
       the set of physical volumes [devices] *)
 
-  val write: Block.t list -> t -> t S.io
+  val write: (t * devices) -> t S.io
   (** [write devices t] flushes the metadata of [t] to the physical volumes *)
 
 end

--- a/lib/vg.mli
+++ b/lib/vg.mli
@@ -71,10 +71,6 @@ module Make : functor(Block: S.BLOCK) -> sig
   (** [read devices] reads the volume group information from
       the set of physical volumes [devices] *)
 
-  val update: t -> Redo.Op.t -> (t, string) Result.result
+  val update: t -> Redo.Op.t -> t S.io
   (** [update t update] replaces the metadata within [t] with [update] *)
-
-  val write: t -> t S.io
-  (** [write devices t] flushes the metadata of [t] to the physical volumes *)
-
 end

--- a/lib_test/vg_test.ml
+++ b/lib_test/vg_test.ml
@@ -64,9 +64,9 @@ let mirage_lv_name_clash () =
         with_block filename
           (fun block ->
             Vg_IO.format "vg" [ pv, block ] >>|= fun () ->
-            Vg_IO.read [ block ] >>|= fun (vg, _devices) ->
-            Vg.create vg "name" size >>*= fun (vg,_) ->
-            expect_failure (Vg.create vg "name") size >>*= 
+            Vg_IO.read [ block ] >>|= fun vg ->
+            Vg.create (Vg_IO.metadata_of vg) "name" size >>*= fun (md,_) ->
+            expect_failure (Vg.create md "name") size >>*= 
             Lwt.return
           )
       in

--- a/lib_test/vg_test.ml
+++ b/lib_test/vg_test.ml
@@ -64,7 +64,7 @@ let mirage_lv_name_clash () =
         with_block filename
           (fun block ->
             Vg_IO.format "vg" [ pv, block ] >>|= fun () ->
-            Vg_IO.read [ block ] >>|= fun vg ->
+            Vg_IO.read [ block ] >>|= fun (vg, _devices) ->
             Vg.create vg "name" size >>*= fun (vg,_) ->
             expect_failure (Vg.create vg "name") size >>*= 
             Lwt.return

--- a/lib_test/vg_test.ml
+++ b/lib_test/vg_test.ml
@@ -63,7 +63,7 @@ let mirage_lv_name_clash () =
       let t = 
         with_block filename
           (fun block ->
-            Vg_IO.format "vg" [ block, pv ] >>|= fun () ->
+            Vg_IO.format "vg" [ pv, block ] >>|= fun () ->
             Vg_IO.read [ block ] >>|= fun vg ->
             Vg.create vg "name" size >>*= fun (vg,_) ->
             expect_failure (Vg.create vg "name") size >>*= 

--- a/mapper/mapper.mli
+++ b/mapper/mapper.mli
@@ -13,7 +13,7 @@
  *)
 open Lvm
 
-val name_of: Vg.t -> Lv.t -> string
+val name_of: Vg.metadata -> Lv.t -> string
 (** [name_of vg lv] returns the conventional name used for a device mapper
     device corresponding to [lv]. Device mapper devices are arbitrary but this
     is the naming convention that LVM uses. *)
@@ -28,7 +28,7 @@ type devices
 val read: string list -> devices Lwt.t
 (** Read the LVM headers on a set of local physical devices *)
 
-val to_targets: devices -> Vg.t -> Lv.t -> Devmapper.Target.t list
+val to_targets: devices -> Vg.metadata -> Lv.t -> Devmapper.Target.t list
 (** [to_targets devices vg lv] returns the device mapper targets needed to access
     the data stored within [lv], where [devices] are the local physical
     disks containing the PVs. *)

--- a/src/impl.ml
+++ b/src/impl.ml
@@ -111,7 +111,7 @@ let format common filename vgname pvname journalled =
       let t =
         with_block filename
           (fun x ->
-            Vg_IO.format vgname ~magic:(if journalled then `Journalled else `Lvm) [ x, pvname ] >>|= fun () ->
+            Vg_IO.format vgname ~magic:(if journalled then `Journalled else `Lvm) [ pvname, x ] >>|= fun () ->
             return ()
           ) in
       Lwt_main.run t;

--- a/src/impl.ml
+++ b/src/impl.ml
@@ -156,9 +156,9 @@ let update_vg common filename f =
       with_block filename
         (fun x ->
           let devices = [ x ] in
-          Vg_IO.read devices >>|= fun (vg, _devices) ->
+          Vg_IO.read devices >>|= fun (vg, devices) ->
           f vg >>*= fun (vg,_) ->
-          Vg_IO.write devices vg >>|= fun _ ->
+          Vg_IO.write (vg, devices) >>|= fun _ ->
           return ()
         ) in
     Lwt_main.run t;

--- a/src/impl.ml
+++ b/src/impl.ml
@@ -158,8 +158,7 @@ let update_vg common filename f =
           let devices = [ x ] in
           Vg_IO.read devices >>|= fun vg ->
           f (Vg_IO.metadata_of vg) >>*= fun (_,op) ->
-          Vg_IO.update vg op >>*= fun vg ->
-          Vg_IO.write vg >>|= fun _ ->
+          Vg_IO.update vg op >>|= fun _ ->
           return ()
         ) in
     Lwt_main.run t;

--- a/src/impl.ml
+++ b/src/impl.ml
@@ -157,8 +157,9 @@ let update_vg common filename f =
         (fun x ->
           let devices = [ x ] in
           Vg_IO.read devices >>|= fun vg ->
-          f (Vg_IO.metadata_of vg) >>*= fun (md,_) ->
-          Vg_IO.write (Vg_IO.update vg md) >>|= fun _ ->
+          f (Vg_IO.metadata_of vg) >>*= fun (_,op) ->
+          Vg_IO.update vg op >>*= fun vg ->
+          Vg_IO.write vg >>|= fun _ ->
           return ()
         ) in
     Lwt_main.run t;

--- a/src/impl.ml
+++ b/src/impl.ml
@@ -158,7 +158,7 @@ let update_vg common filename f =
           let devices = [ x ] in
           Vg_IO.read devices >>|= fun vg ->
           f (Vg_IO.metadata_of vg) >>*= fun (_,op) ->
-          Vg_IO.update vg op >>|= fun _ ->
+          Vg_IO.update vg [ op ] >>|= fun _ ->
           return ()
         ) in
     Lwt_main.run t;

--- a/src/impl.ml
+++ b/src/impl.ml
@@ -93,7 +93,7 @@ let read common filename =
           Vg_IO.read [ x ] >>|= fun vg ->
           return vg 
         )in
-    let vg = Lwt_main.run t in
+    let vg, _devices = Lwt_main.run t in
     Common.print_table [ "key"; "value" ] (table_of_vg vg);
     `Ok ()
   with
@@ -129,7 +129,7 @@ let map common filename lvname =
     let t =
       with_block filename
         (fun x ->
-          Vg_IO.read [ x ] >>|= fun vg ->
+          Vg_IO.read [ x ] >>|= fun (vg, _devices) ->
           let lv = List.find (fun lv -> lv.Lv.name = lvname) vg.Vg.lvs in
           List.iter (fun seg ->
             Printf.printf "start %Ld, count %Ld %s\n" seg.Lv.Segment.start_extent seg.Lv.Segment.extent_count
@@ -156,7 +156,7 @@ let update_vg common filename f =
       with_block filename
         (fun x ->
           let devices = [ x ] in
-          Vg_IO.read devices >>|= fun vg ->
+          Vg_IO.read devices >>|= fun (vg, _devices) ->
           f vg >>*= fun (vg,_) ->
           Vg_IO.write devices vg >>|= fun _ ->
           return ()


### PR DESCRIPTION
- the Vg type now packages up the BLOCK devices and the metadata
- add a Volume module which exposes an LV as a BLOCK device
