### PR TITLE
Add a [ `RO | `RW ] flag to Vg.Make().connect

### DIFF
--- a/lib/vg.mli
+++ b/lib/vg.mli
@@ -61,9 +61,11 @@ module Make(Log: S.LOG)(Block: S.BLOCK) : sig
   (** [format name devices_and_names] initialises a new volume group
       with name [name], using physical volumes [devices] *)
 
-  val connect: Block.t list -> vg S.io
-  (** [connect devices] opens a volume group contained on [devices]
-      for reading and writing *)
+  val connect: Block.t list -> [ `RO | `RW ] -> vg S.io
+  (** [connect disks flag] opens a volume group contained on [devices].
+      If `RO is provided then no updates will be persisted to disk,
+      this is particularly useful if the volume group is opened for writing
+      somewhere else. *)
 
   val update: vg -> Redo.Op.t list -> unit S.io
   (** [update t updates] performs the operations [updates] and ensures

--- a/lib_test/vg_test.ml
+++ b/lib_test/vg_test.ml
@@ -73,7 +73,7 @@ let mirage_lv_name_clash () =
         with_block filename
           (fun block ->
             Vg_IO.format "vg" [ pv, block ] >>|= fun () ->
-            Vg_IO.connect [ block ] >>|= fun vg ->
+            Vg_IO.connect [ block ] `RW >>|= fun vg ->
             Vg.create (Vg_IO.metadata_of vg) "name" size >>*= fun (md,_) ->
             expect_failure (Vg.create md "name") size >>*= 
             Lwt.return

--- a/src/impl.ml
+++ b/src/impl.ml
@@ -96,7 +96,7 @@ let read common filename =
     let t =
       with_block filename
         (fun x ->
-          Vg_IO.connect [ x ] >>|= fun vg ->
+          Vg_IO.connect [ x ] `RO >>|= fun vg ->
           return vg 
         )in
     let vg = Lwt_main.run t in
@@ -135,7 +135,7 @@ let map common filename lvname =
     let t =
       with_block filename
         (fun x ->
-          Vg_IO.connect [ x ] >>|= fun vg ->
+          Vg_IO.connect [ x ] `RO >>|= fun vg ->
           let lv = List.find (fun lv -> lv.Lv.name = lvname) (Vg_IO.metadata_of vg).Vg.lvs in
           List.iter (fun seg ->
             Printf.printf "start %Ld, count %Ld %s\n" seg.Lv.Segment.start_extent seg.Lv.Segment.extent_count
@@ -162,7 +162,7 @@ let update_vg common filename f =
       with_block filename
         (fun x ->
           let devices = [ x ] in
-          Vg_IO.connect devices >>|= fun vg ->
+          Vg_IO.connect devices `RW >>|= fun vg ->
           f (Vg_IO.metadata_of vg) >>*= fun (_,op) ->
           Vg_IO.update vg [ op ] >>|= fun () ->
           Vg_IO.sync vg >>|= fun () ->


### PR DESCRIPTION
This allows a volume group to be opened 'read-only' such that
we won't try to replay the redo-log and corrupt it when it is
opened for writing somewhere else.

Fixes #33

Signed-off-by: David Scott dave.scott@citrix.com
