### PR TITLE
Start shifting to a RResult-style result type

### DIFF
--- a/lib/allocator.ml
+++ b/lib/allocator.ml
@@ -146,7 +146,7 @@ let find (free_list : t) (newsize : int64) =
     match safe_alloc free_list newsize
     with  Some (x, _) -> `Ok x
 	| None ->
-          `Error (size free_list)
+          `Error (`OnlyThisMuchFree (size free_list))
 
 (* Probably de-allocation won't be used much. *)
 let merge to_free free_list = normalize (combine to_free free_list)

--- a/lib/expect.ml
+++ b/lib/expect.ml
@@ -20,6 +20,8 @@ let o = fun f g x -> f (g x)
 
 open Result
 
+let fail msg = `Error (`Msg msg)
+
 let expect_string name field =
   match field with 
     | AStr s -> return s

--- a/lib/label.ml
+++ b/lib/label.ml
@@ -57,7 +57,7 @@ module Label_header = struct
     let crc_check = Cstruct.sub b0 20 (Constants.label_size - 20) in
     let calculated_crc = Crc.crc crc_check in
     if calculated_crc <> crc_xl
-    then `Error (Printf.sprintf "Label_header: bad checksum, expected %08lx, got %08lx" calculated_crc crc_xl)
+    then `Error (`Msg (Printf.sprintf "Label_header: bad checksum, expected %08lx, got %08lx" calculated_crc crc_xl))
     else `Ok ({id=id;
      sector=sector_xl;
      crc=crc_xl;
@@ -171,7 +171,7 @@ let unmarshal buf =
   let open Label_header in
   let rec find n =
     if n > 3
-    then `Error "No PV label found in any of the first 4 sectors"
+    then `Error (`Msg "No PV label found in any of the first 4 sectors")
     else begin
       let b = Cstruct.shift buf (n * Constants.sector_size) in
       if Cstruct.(to_string (sub b 0 8)) = Constants.label_id then begin

--- a/lib/lv.mli
+++ b/lib/lv.mli
@@ -23,7 +23,7 @@ module Status : sig
 
   include S.PRINT with type t := t
 
-  val of_string: string -> (t, string) Result.result
+  val of_string: string -> (t, [ `Msg of string ]) Result.result
 end
 
 module Linear : sig
@@ -70,7 +70,7 @@ type t = {
 include S.SEXPABLE with type t := t
 include S.MARSHAL with type t := t
 
-val of_metadata: string -> (string * Absty.absty) list -> (t, string) Result.result
+val of_metadata: string -> (string * Absty.absty) list -> (t, [ `Msg of string ]) Result.result
 
 val to_allocation: t -> (Pv.Name.t * (int64 * int64)) list
 
@@ -79,5 +79,5 @@ val size_in_extents: t -> int64
 val find_extent: t -> int64 -> Segment.t option
 (** [find_extent t x] returns the segment containing [x] *)
 
-val reduce_size_to: t -> int64 -> (t, string) Result.result
+val reduce_size_to: t -> int64 -> (t, [ `Msg of string ]) Result.result
 (** [reduce_size_to lv new_size] reduces the size of [lv] to [new_size] *)

--- a/lib/magic.ml
+++ b/lib/magic.ml
@@ -29,7 +29,7 @@ let marshal t buf =
 
 let unmarshal buf =
   if Cstruct.len buf < length
-  then `Error "Buffer is too small for a magic string"
+  then `Error (`Msg "Buffer is too small for a magic string")
   else begin
     let m = Cstruct.(to_string (sub buf 0 length)) in
     let rest = Cstruct.shift buf length in
@@ -37,5 +37,5 @@ let unmarshal buf =
     then `Ok (`Lvm, rest)
     else if m = journal_magic
     then `Ok (`Journalled, rest)
-    else `Error (Printf.sprintf "Failed to parse magic string '%s'" (String.escaped m))
+    else `Error (`Msg (Printf.sprintf "Failed to parse magic string '%s'" (String.escaped m)))
   end

--- a/lib/metadata.ml
+++ b/lib/metadata.ml
@@ -76,7 +76,7 @@ module Header = struct
     let crc_to_check = Cstruct.sub buf 4 (sizeof - 4) in
     let crc = Crc.crc crc_to_check in
     if crc <> mdah_checksum
-    then `Error (Printf.sprintf "Bad checksum in metadata area: expected %08lx, got %08lx" mdah_checksum crc)
+    then `Error (`Msg (Printf.sprintf "Bad checksum in metadata area: expected %08lx, got %08lx" mdah_checksum crc))
     else `Ok ({mdah_checksum; mdah_magic; mdah_version; mdah_start; mdah_size; mdah_raw_locns}, b)
 
   let to_string mdah = Sexplib.Sexp.to_string_hum (sexp_of_t mdah)
@@ -169,7 +169,7 @@ let read dev mdah n =
   Cstruct.blit buf' 0 result firstbit secondbit;
   let checksum = Crc.crc result in
   if checksum <> locn.mrl_checksum
-  then Lwt.return (`Error (Printf.sprintf "Ignoring invalid checksum in metadata: Found %lx, expecting %lx" checksum locn.mrl_checksum))
+  then Lwt.return (`Error (`Msg (Printf.sprintf "Ignoring invalid checksum in metadata: Found %lx, expecting %lx" checksum locn.mrl_checksum)))
   else return result
       
 let write device mdah md =

--- a/lib/name.ml
+++ b/lib/name.ml
@@ -15,6 +15,8 @@
 open Sexplib.Std
 open Result
 
+let fail msg = `Error (`Msg msg)
+
 module CharSet = struct
   include Set.Make(struct type t = char let compare = compare end)
 
@@ -51,9 +53,8 @@ module type Sanitised_string = sig
   type t
   include S.SEXPABLE with type t := t
   include S.PRINT with type t := t
-  val of_string : string -> (t, string) Result.result
+  val of_string : string -> (t, [ `Msg of string ]) Result.result
 end
-
 
 module Make(Constraints : CONSTRAINTS) = struct
   open Constraints

--- a/lib/name.mli
+++ b/lib/name.mli
@@ -16,7 +16,7 @@ module type Sanitised_string = sig
   type t
   include S.SEXPABLE with type t := t
   include S.PRINT with type t := t
-  val of_string : string -> (t, string) Result.result
+  val of_string : string -> (t, [ `Msg of string ]) Result.result
 end
 
 module Vg_name : Sanitised_string

--- a/lib/pv.ml
+++ b/lib/pv.ml
@@ -22,6 +22,8 @@ open Expect
 
 open Result
 
+let fail msg = `Error (`Msg msg)
+
 module Status = struct  
   type t = 
     | Allocatable

--- a/lib/pv.mli
+++ b/lib/pv.mli
@@ -19,7 +19,7 @@ module Status : sig
 
   include S.PRINT with type t := t
 
-  val of_string: string -> (t, string) Result.result
+  val of_string: string -> (t, [ `Msg of string ]) Result.result
 end
 
 module Name : sig
@@ -27,7 +27,7 @@ module Name : sig
 
   val to_string: t -> string
 
-  val of_string: string -> (t, string) Result.result
+  val of_string: string -> (t, [ `Msg of string ]) Result.result
 end
 
 type t = {

--- a/lib/result.ml
+++ b/lib/result.ml
@@ -25,7 +25,7 @@ let ( >>| ) = map
 
 let return x = `Ok x
 let ok = return
-let fail x = `Error x
+let fail x = `Error (`Msg x)
 
 let all xs =
   let rec loop acc = function
@@ -34,6 +34,10 @@ let all xs =
   | `Error x :: _ -> `Error x in
   loop [] xs
 
-let ok_or_failwith = function
-  | `Ok x -> x
-  | `Error x -> failwith x
+let get_ok = function
+| `Ok x -> x
+| `Error _ -> raise (Invalid_argument "get_ok encountered an `Error")
+
+let get_error = function
+| `Error x -> x
+| `Ok _ -> raise (Invalid_argument "get_error encountered an `Ok")

--- a/lib/result.mli
+++ b/lib/result.mli
@@ -20,8 +20,8 @@ type ('a, 'b) result = [
 include Monad.S2 with type ('a, 'b) t := ('a, 'b) result
 
 val ok: 'a -> ('a, 'b) result
-val fail: 'b -> ('a, 'b) result
 
 val all: ('a, 'b) result list -> ('a list, 'b) result
 
-val ok_or_failwith: ('a, string) result -> 'a
+val get_ok: ('a, 'b) result -> 'a
+val get_error: ('a, 'b) result -> 'b

--- a/lib/s.mli
+++ b/lib/s.mli
@@ -24,7 +24,7 @@ end
 
 module type UNMARSHAL = sig
   type t
-  val unmarshal: Cstruct.t -> (t * Cstruct.t, string) Result.result
+  val unmarshal: Cstruct.t -> (t * Cstruct.t, [ `Msg of string ]) Result.result
 end
 
 module type EQUALS = sig
@@ -44,7 +44,7 @@ module type LOG = sig
   val error : ('a, unit, string, unit) format4 -> 'a
 end
 
-type 'a io = ('a, string) Result.result Lwt.t
+type 'a io = ('a, [ `Msg of string ]) Result.result Lwt.t
 
 module type BLOCK = V1_LWT.BLOCK
 
@@ -69,29 +69,29 @@ module type VOLUME = sig
   (** The status of an individual LV *)
   
   val create: t -> name -> ?tags:tag list -> ?status:lv_status list -> int64 ->
-    (t * op, string) Result.result
+    (t * op, [ `Msg of string ]) Result.result
   (** [create t name size] extends the volume group [t] with a new
       volume named [name] with size at least [size] bytes. The actual
       size of the volume may be rounded up. *)
 
-  val rename: t -> name -> name -> (t * op, string) Result.result
+  val rename: t -> name -> name -> (t * op, [ `Msg of string ]) Result.result
   (** [rename t name new_name] returns a new volume group [t] where
       the volume previously named [name] has been renamed to [new_name] *)
 
-  val resize: t -> name -> size -> (t * op, string) Result.result
+  val resize: t -> name -> size -> (t * op, [ `Msg of string ]) Result.result
   (** [resize t name new_size] returns a new volume group [t] where
       the volume with [name] has new size at least [new_size]. The
       size of the volume may be rounded up. *)
  
-  val remove: t -> name -> (t * op, string) Result.result
+  val remove: t -> name -> (t * op, [ `Msg of string]) Result.result
   (** [remove t name] returns a new volume group [t] where the volume
       with [name] has been deallocated. *)
 
-  val add_tag: t -> name -> tag -> (t * op, string) Result.result
+  val add_tag: t -> name -> tag -> (t * op, [ `Msg of string]) Result.result
   (** [add_tag t name tag] returns a new volume group [t] where the
       volume with [name] has a new tag [tag] *)
 
-  val remove_tag: t -> name -> tag -> (t * op, string) Result.result
+  val remove_tag: t -> name -> tag -> (t * op, [ `Msg of string]) Result.result
   (** [remove_tag t name tag] returns a new volume group [t] where the
       volume with [name] has no tag [tag] *)
 end
@@ -127,7 +127,7 @@ module type ALLOCATOR = sig
       total amount of space currently free, which is insufficient to satisfy
       the request.
       The expected use is to 'allocate' space for a logical volume. *)
-  val find : t -> int64 -> (t, int64) Result.result
+  val find : t -> int64 -> (t, [ `OnlyThisMuchFree of int64 ]) Result.result
 
   (** [merge t1 t2] returns a region [t] which contains all the physical
       space from both [t1] and [t2].

--- a/lib/unalignedBlock.ml
+++ b/lib/unalignedBlock.ml
@@ -15,10 +15,10 @@
 open Lwt
 
 let block_error = function
-  | `Unknown x -> `Error x
-  | `Unimplemented -> `Error "unimplemented"
-  | `Is_read_only -> `Error "device is read-only"
-  | `Disconnected -> `Error "disconnected"
+  | `Unknown x -> `Error (`Msg x)
+  | `Unimplemented -> `Error (`Msg "unimplemented")
+  | `Is_read_only -> `Error (`Msg "device is read-only")
+  | `Disconnected -> `Error (`Msg "disconnected")
 
 module IO = struct
   let ( >>= ) m f = m >>= function

--- a/lib/uuid.ml
+++ b/lib/uuid.ml
@@ -50,7 +50,7 @@ include Result
 
 let unmarshal buf =
   if Cstruct.len buf < sizeof
-  then `Error (Printf.sprintf "Uuid.unmarshal: buffer is too small \"%s\"" (String.escaped (Cstruct.to_string buf)))
+  then `Error (`Msg (Printf.sprintf "Uuid.unmarshal: buffer is too small \"%s\"" (String.escaped (Cstruct.to_string buf))))
   else
     (* We aren't checking for valid characters in the uuid: we're
        being tolerant in what we expect but strict in what we create *)
@@ -67,9 +67,9 @@ let to_string x = x
 let of_string x =
   let expected_length = sizeof + (List.length format - 1) in
   if String.length x <> expected_length
-  then `Error(Printf.sprintf "Uuid.of_string: string is too short \"%s\"" x)
+  then `Error (`Msg (Printf.sprintf "Uuid.of_string: string is too short \"%s\"" x))
   else
     let x' = remove_hyphens x in
     if String.length x' <> sizeof
-    then `Error(Printf.sprintf "Uuid.of_string: string has the wrong number of hyphens \"%s\"" x)
+    then `Error(`Msg (Printf.sprintf "Uuid.of_string: string has the wrong number of hyphens \"%s\"" x))
     else `Ok x

--- a/lib/uuid.mli
+++ b/lib/uuid.mli
@@ -27,6 +27,6 @@ include Monad.S2 with type ('a, 'b) t := ('a, 'b) Result.result
 val create: unit -> t
 (** [create ()] generates a fresh uuid *)
 
-val of_string: string -> (t, string) Result.result
+val of_string: string -> (t, [ `Msg of string ]) Result.result
 (** [of_string s] returns [t] corresponding to [s] *)
 

--- a/lib/vg.mli
+++ b/lib/vg.mli
@@ -22,7 +22,7 @@ module Status : sig
 
   include S.PRINT with type t := t
 
-  val of_string: string -> (t, string) Result.result
+  val of_string: string -> (t, [ `Msg of string ]) Result.result
 end
 
 type metadata = {
@@ -39,7 +39,7 @@ type metadata = {
 } with sexp
 (** A volume group *)
 
-val do_op: metadata -> Redo.Op.t -> (metadata * Redo.Op.t, string) Result.result
+val do_op: metadata -> Redo.Op.t -> (metadata * Redo.Op.t, [ `Msg of string ]) Result.result
 (** [do_op t op] performs [op], returning the modified volume group [t] *)
 
 include S.MARSHAL with type t := metadata

--- a/mapper/mapper.ml
+++ b/mapper/mapper.ml
@@ -43,7 +43,7 @@ let read devices =
       (fun t ->
         Label_IO.read t
         >>= function
-        | `Error x -> fail (Failure x)
+        | `Error (`Msg x) -> fail (Failure x)
         | `Ok x -> return (x.Label.pv_header.Label.Pv_header.id, device)
       )
   ) devices

--- a/src/impl.ml
+++ b/src/impl.ml
@@ -22,10 +22,10 @@ let require name arg = match arg with
   | Some x -> x
 
 let (>>|=) m f = m >>= function
-  | `Error e -> fail (Failure e)
+  | `Error (`Msg e) -> fail (Failure e)
   | `Ok x -> f x
 let (>>*=) m f = match m with
-  | `Error e -> fail (Failure e)
+  | `Error (`Msg e) -> fail (Failure e)
   | `Ok x -> f x
 
 let apply common =
@@ -111,7 +111,7 @@ let format common filename vgname pvname journalled =
   try
     let filename = require "filename" filename in
     begin match Pv.Name.of_string pvname with
-    | `Error x -> failwith x
+    | `Error (`Msg x) -> failwith x
     | `Ok pvname ->
       let t =
         with_block filename


### PR DESCRIPTION
- update to new shared-block-ring API
- switch from ('a, string) result to ('a, [ `Msg of string ]) result

Signed-off-by: David Scott dave.scott@citrix.com
