### PR TITLE
Expand the error type to include handleable conditions

### DIFF
--- a/lib/iO.ml
+++ b/lib/iO.ml
@@ -14,7 +14,6 @@
 
 open Lwt
 
-type 'a io = ('a, string) Result.result Lwt.t 
 type ('a, 'b) t = ('a, 'b) Result.result Lwt.t
 
 open S

--- a/lib/label.mli
+++ b/lib/label.mli
@@ -64,12 +64,19 @@ include S.PRINT with type t := t
 include S.MARSHAL with type t := t
 include S.UNMARSHAL with type t := t
 include S.SEXPABLE with type t := t
-include Monad.S2 with type ('a, 'b) t := ('a, 'b) Result.result
 
 val get_metadata_locations: t -> Location.t list
 
-module Make : functor(Block: S.BLOCK) -> sig
-  val read: Block.t -> t S.io
+type error = [
+  | `Msg of string
+]
 
-  val write: Block.t -> t -> unit S.io
+type 'a result = ('a, error) Result.result
+
+val open_error: 'a result -> ('a, [> error]) Result.result
+
+module Make : functor(Block: S.BLOCK) -> sig
+  val read: Block.t -> t result Lwt.t
+
+  val write: Block.t -> t -> unit result Lwt.t
 end

--- a/lib/lv.mli
+++ b/lib/lv.mli
@@ -79,5 +79,5 @@ val size_in_extents: t -> int64
 val find_extent: t -> int64 -> Segment.t option
 (** [find_extent t x] returns the segment containing [x] *)
 
-val reduce_size_to: t -> int64 -> (t, [ `Msg of string ]) Result.result
+val reduce_size_to: t -> int64 -> (t, [> `Msg of string ]) Result.result
 (** [reduce_size_to lv new_size] reduces the size of [lv] to [new_size] *)

--- a/lib/metadata.ml
+++ b/lib/metadata.ml
@@ -21,6 +21,15 @@ open Absty
 
 open IO
 
+type error = [
+  | `Msg of string
+]
+type 'a result = ('a, error) Result.result
+
+let open_error = function
+  | `Ok x -> `Ok x
+  | `Error (`Msg x) -> `Error (`Msg x)
+
 let default_start = 4096L
 let default_size = Int64.mul 10240L 1024L (* 10 MiB *)
 

--- a/lib/name.ml
+++ b/lib/name.ml
@@ -15,6 +15,12 @@
 open Sexplib.Std
 open Result
 
+type error = [ `Msg of string ]
+type 'a result = ('a, error) Result.result
+let open_error = function
+  | `Ok x -> `Ok x
+  | `Error (`Msg x) -> `Error (`Msg x)
+
 let fail msg = `Error (`Msg msg)
 
 module CharSet = struct

--- a/lib/name.mli
+++ b/lib/name.mli
@@ -12,6 +12,10 @@
  * GNU Lesser General Public License for more details.
  *)
 
+type error = [ `Msg of string ]
+type 'a result = ('a, error) Result.result
+val open_error: 'a result -> ('a, [> error ]) Result.result
+
 module type Sanitised_string = sig
   type t
   include S.SEXPABLE with type t := t

--- a/lib/pv.ml
+++ b/lib/pv.ml
@@ -22,6 +22,16 @@ open Expect
 
 open Result
 
+type error = [
+  | `Msg of string
+]
+
+type 'a result = ('a, error) Result.result
+
+let open_error = function
+  | `Ok x -> `Ok x
+  | `Error (`Msg x) -> `Error (`Msg x)
+
 let fail msg = `Error (`Msg msg)
 
 module Status = struct  

--- a/lib/s.mli
+++ b/lib/s.mli
@@ -44,7 +44,12 @@ module type LOG = sig
   val error : ('a, unit, string, unit) format4 -> 'a
 end
 
-type 'a io = ('a, [ `Msg of string ]) Result.result Lwt.t
+type error = [
+  | `UnknownLV of string
+  | `DuplicateLV of string
+  | `OnlyThisMuchFree of int64
+  | `Msg of string
+]
 
 module type BLOCK = V1_LWT.BLOCK
 
@@ -67,31 +72,35 @@ module type VOLUME = sig
 
   type lv_status
   (** The status of an individual LV *)
-  
+ 
+  type error
+
+  type 'a result = ('a, error) Result.result
+ 
   val create: t -> name -> ?tags:tag list -> ?status:lv_status list -> int64 ->
-    (t * op, [ `Msg of string ]) Result.result
+    (t * op) result
   (** [create t name size] extends the volume group [t] with a new
       volume named [name] with size at least [size] bytes. The actual
       size of the volume may be rounded up. *)
 
-  val rename: t -> name -> name -> (t * op, [ `Msg of string ]) Result.result
+  val rename: t -> name -> name -> (t * op) result
   (** [rename t name new_name] returns a new volume group [t] where
       the volume previously named [name] has been renamed to [new_name] *)
 
-  val resize: t -> name -> size -> (t * op, [ `Msg of string ]) Result.result
+  val resize: t -> name -> size -> (t * op) result
   (** [resize t name new_size] returns a new volume group [t] where
       the volume with [name] has new size at least [new_size]. The
       size of the volume may be rounded up. *)
  
-  val remove: t -> name -> (t * op, [ `Msg of string]) Result.result
+  val remove: t -> name -> (t * op) result
   (** [remove t name] returns a new volume group [t] where the volume
       with [name] has been deallocated. *)
 
-  val add_tag: t -> name -> tag -> (t * op, [ `Msg of string]) Result.result
+  val add_tag: t -> name -> tag -> (t * op) result
   (** [add_tag t name tag] returns a new volume group [t] where the
       volume with [name] has a new tag [tag] *)
 
-  val remove_tag: t -> name -> tag -> (t * op, [ `Msg of string]) Result.result
+  val remove_tag: t -> name -> tag -> (t * op) result
   (** [remove_tag t name tag] returns a new volume group [t] where the
       volume with [name] has no tag [tag] *)
 end

--- a/lib/uuid.ml
+++ b/lib/uuid.ml
@@ -17,6 +17,16 @@ open Sexplib.Std
 
 type t = string with sexp
 
+type error = [
+  | `Msg of string
+]
+
+type 'a result = ('a, error) Result.result
+
+let open_error = function
+  | `Ok x -> `Ok x
+  | `Error (`Msg x) -> `Error (`Msg x)
+
 let format = [6; 4; 4; 4; 4; 4; 6] 
 
 let charlist = "0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ!#"
@@ -46,9 +56,8 @@ let remove_hyphens str =
 
 let sizeof = 32
 
-include Result
-
 let unmarshal buf =
+  let open Result in
   if Cstruct.len buf < sizeof
   then `Error (`Msg (Printf.sprintf "Uuid.unmarshal: buffer is too small \"%s\"" (String.escaped (Cstruct.to_string buf))))
   else

--- a/lib/uuid.mli
+++ b/lib/uuid.mli
@@ -18,11 +18,18 @@
 type t
 (** An LVM 'uuid'. Note this isn't a valid uuid according to RFC4122 *)
 
+type error = [
+ | `Msg of string
+]
+
+type 'a result = ('a, error) Result.result
+
+val open_error: 'a result -> ('a, [> error]) Result.result
+
 include S.PRINT with type t := t
 include S.SEXPABLE with type t := t
 include S.MARSHAL with type t := t
 include S.UNMARSHAL with type t := t
-include Monad.S2 with type ('a, 'b) t := ('a, 'b) Result.result
 
 val create: unit -> t
 (** [create ()] generates a fresh uuid *)

--- a/src/impl.ml
+++ b/src/impl.ml
@@ -21,12 +21,13 @@ let require name arg = match arg with
   | None -> failwith (Printf.sprintf "Please supply a %s argument" name)
   | Some x -> x
 
-let (>>|=) m f = m >>= function
-  | `Error (`Msg e) -> fail (Failure e)
-  | `Ok x -> f x
 let (>>*=) m f = match m with
   | `Error (`Msg e) -> fail (Failure e)
+  | `Error (`DuplicateLV x) -> fail (Failure (Printf.sprintf "%s is a duplicate LV name" x))
+  | `Error (`OnlyThisMuchFree x) -> fail (Failure (Printf.sprintf "There is only %Ld free" x))
+  | `Error (`UnknownLV x) -> fail (Failure (Printf.sprintf "I couldn't find an LV named %s" x))
   | `Ok x -> f x
+let (>>|=) m f = m >>= fun x -> x >>*= f
 
 let apply common =
   ()


### PR DESCRIPTION
Clients need to be able to respond to errors like
- an LV name is already used
- an LV name was not found
- not enough space

Signed-off-by: David Scott dave.scott@citrix.com
