### PR TITLE
Impose a minimum flush_interval, configured at connect-time

### DIFF
--- a/_oasis
+++ b/_oasis
@@ -39,7 +39,7 @@ Executable mlvm
   MainIs:             main.ml
   Custom:             true
   Install:            false
-  BuildDepends:       lvm, cmdliner, io-page.unix, io-page, mirage-block-unix, io-page.unix
+  BuildDepends:       lvm, cmdliner, io-page.unix, io-page, mirage-block-unix, io-page.unix, mirage-clock-unix
 
 Executable vg_test
   CompiledObject:     best
@@ -47,7 +47,7 @@ Executable vg_test
   MainIs:             vg_test.ml
   Custom:             true
   Install:            false
-  BuildDepends:       lvm, oUnit, io-page.unix, io-page, mirage-block-unix, io-page.unix, bisect
+  BuildDepends:       lvm, oUnit, io-page.unix, io-page, mirage-block-unix, mirage-clock-unix, io-page.unix, bisect
 
 Test vg_test
   Command:            ./vg_test.native

--- a/lib/s.mli
+++ b/lib/s.mli
@@ -52,6 +52,8 @@ type error = [
 ]
 
 module type BLOCK = V1_LWT.BLOCK
+module type TIME = V1_LWT.TIME
+module type CLOCK = V1.CLOCK
 
 module type VOLUME = sig
 

--- a/opam
+++ b/opam
@@ -26,5 +26,6 @@ depends: [
   "oasis"
   "io-page" {> "1.2.0"}
   "mirage-block-unix"
+  "mirage-clock-unix"
   "cmdliner"
 ]

--- a/src/impl.ml
+++ b/src/impl.ml
@@ -88,9 +88,14 @@ module Log = struct
   let error fmt = Printf.ksprintf (fun s -> print_endline s) fmt
 end
 
+module Time = struct
+  type 'a io = 'a Lwt.t
+  let sleep = Lwt_unix.sleep
+end
+
 let read common filename =
   apply common;
-  let module Vg_IO = Vg.Make(Log)(Block) in
+  let module Vg_IO = Vg.Make(Log)(Block)(Time)(Clock) in
   try
     let filename = require "filename" filename in
     let t =
@@ -108,7 +113,7 @@ let read common filename =
 
 let format common filename vgname pvname journalled =
   apply common;
-  let module Vg_IO = Vg.Make(Log)(Block) in
+  let module Vg_IO = Vg.Make(Log)(Block)(Time)(Clock) in
   try
     let filename = require "filename" filename in
     begin match Pv.Name.of_string pvname with
@@ -129,7 +134,7 @@ let format common filename vgname pvname journalled =
 
 let map common filename lvname =
   apply common;
-  let module Vg_IO = Vg.Make(Log)(Block) in
+  let module Vg_IO = Vg.Make(Log)(Block)(Time)(Clock) in
   try
     let filename = require "filename" filename in
     let t =
@@ -154,7 +159,7 @@ let map common filename lvname =
 
 let update_vg common filename f =
   apply common;
-  let module Vg_IO = Vg.Make(Log)(Block) in
+  let module Vg_IO = Vg.Make(Log)(Block)(Time)(Clock) in
   try
     let filename = require "filename" filename in
     let t =


### PR DESCRIPTION
To work efficiently we wish to buffer updates before flushing to the
primary metadata area, as the flush is very expensive. The default will
be to impose a gap of 5s between metadata flushes.

Signed-off-by: David Scott dave.scott@citrix.com
