### PR TITLE
Make LvRemove operation idempotent

### DIFF
--- a/lib/vg.ml
+++ b/lib/vg.ml
@@ -204,9 +204,10 @@ let do_op vg op : (metadata * op) result =
       let free_space = Pv.Allocator.sub (Pv.Allocator.merge vg.free_space allocation) new_allocation in
       return ({vg with lvs = LVs.add lv.Lv.id lv vg.lvs; free_space},op))
   | LvRemove id ->
-    with_lv vg id (fun lv ->
+    begin match with_lv vg id (fun lv ->
       let allocation = Lv.to_allocation lv in
       return ({vg with lvs = LVs.remove lv.Lv.id vg.lvs; free_space = Pv.Allocator.merge vg.free_space allocation },op))
+    with | `Error (`UnknownLV _) -> return (vg, op) | r -> r end
   | LvRename (id, l) ->
     with_lv vg id (fun lv ->
       let lvs = LVs.(add id { lv with Lv.name = l.lvmv_new_name }

--- a/lib_test/vg_test.ml
+++ b/lib_test/vg_test.ml
@@ -570,16 +570,21 @@ let lv_op_idempotence () =
     cls=Lv.Linear.(Linear {name=pv; start_extent=8L})
   } in
   let lv = Lv.({name="lv0"; id=(Uuid.create ()); tags=[]; status=[]; segments=[segment]}) in
+  let open Redo.Op in
   let ops_to_test = [
-    Redo.Op.(LvCreate lv);
-    Redo.Op.(LvReduce(lv.Lv.id, {lvrd_new_extent_count=1L}));
-    Redo.Op.(LvExpand(lv.Lv.id, {lvex_segments=[segment]}));
-    Redo.Op.(LvCrop(lv.Lv.id, {lvc_segments=[{segment with extent_count=1L}]}));
-    Redo.Op.(LvAddTag(lv.Lv.id, Name.Tag.of_string "tag" |> Result.get_ok));
-    Redo.Op.(LvRemoveTag(lv.Lv.id, Name.Tag.of_string "tag" |> Result.get_ok));
-    Redo.Op.(LvSetStatus(lv.Lv.id, Lv.Status.([Read; Write; Visible])));
-    Redo.Op.(LvRename(lv.Lv.id, {lvmv_new_name="lv1"}));
+    LvCreate lv;
+    LvReduce(lv.Lv.id, {lvrd_new_extent_count=1L});
+    LvExpand(lv.Lv.id, {lvex_segments=[segment]});
+    LvCrop(lv.Lv.id, {lvc_segments=[{segment with extent_count=1L}]});
+    LvAddTag(lv.Lv.id, Name.Tag.of_string "tag" |> Result.get_ok);
+    LvRemoveTag(lv.Lv.id, Name.Tag.of_string "tag" |> Result.get_ok);
+    LvSetStatus(lv.Lv.id, Lv.Status.([Read; Write; Visible]));
+    LvRename(lv.Lv.id, {lvmv_new_name="lv1"});
+    LvRemove(lv.Lv.id);
   ] in
+  let _ = function (* Just to make sure this test catches all the ops *)
+  | LvCreate _ | LvRemove _ | LvRename _ | LvReduce _ | LvCrop _ | LvExpand _
+  | LvAddTag _ | LvRemoveTag _ | LvSetStatus _ -> () in
   List.fold_left test_op init_md ops_to_test |> ignore
 
 let lv_tags () =


### PR DESCRIPTION
Also add a dummy function to the unit test to check we've caught all the
operations in Redo.Op.t.

Signed-off-by: Si Beaumont simon.beaumont@citrix.com
