### PR TITLE
Allow clients to discover the PV label magic

### DIFF
--- a/lib/label.ml
+++ b/lib/label.ml
@@ -57,7 +57,14 @@ module Label_header = struct
     offset=32l;
     ty=(if magic = `Lvm then label_type else journalled_label_type);
   }
-    
+
+  let magic_of t =
+    if t.ty = label_type
+    then Some `Lvm
+    else if t.ty = journalled_label_type
+    then Some `Journalled
+    else None
+
   let unmarshal b0 =
     let id = Cstruct.(to_string (sub b0 0 8)) in
     let sector_xl = Cstruct.LE.get_uint64 b0 8 in

--- a/lib/label.mli
+++ b/lib/label.mli
@@ -20,6 +20,10 @@ module Label_header : sig
 
   val create: Magic.t -> t
 
+  val magic_of: t -> Magic.t option
+  (** Return the magic of a particular label, or [None] if we don't
+      recognise the magic. *)
+
   include S.PRINT with type t := t
   include S.EQUALS with type t := t
   include S.MARSHAL with type t := t


### PR DESCRIPTION
This allows clients to figure out if a volume group is using the
new format or the old.

Signed-off-by: David Scott dave.scott@citrix.com
